### PR TITLE
Bench multiple arguments function

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: Allman
+PointerAlignment: Left
+AlignAfterOpenBracket: Align
+AllowAllArgumentsOnNextLine: false
+BinPackArguments: false
+BinPackParameters: false
+AlwaysBreakTemplateDeclarations: Yes
+BreakConstructorInitializers: BeforeComma
+AlignTrailingComments: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The goal of this project is to be forked to serve as a base for anyone needing t
 * [CMake](https://cmake.org/download/)
 * [Conan](https://conan.io/center/)
 
-### Additional libraries included in the conan file
+### Additional libraries
+
+These libraries are included in the conan file. Do not install them yourself. Conan will do the job for you.
 
 * [GoogleTest](https://github.com/google/googletest)
 * [GoogleBenchmark](https://github.com/google/benchmark)
@@ -33,7 +35,7 @@ cd build
 ./bin/Bench
 ```
 
-- Additionnaly you can use "--build missing" to build missing libraries:
+- Additionnaly you can use `--build=missing` to build missing libraries:
 
 ```bash
 conan install .. --build missing
@@ -43,9 +45,9 @@ conan install .. --build missing
 
 ### Additional infos
 
-By default the program **will run in release** when it's inside a build / build_release folder. To build in debug, build the projet inside a build_debug folder.
+* By default the program **will run in release** when it's inside a `build` or `build_release` folder. To build in **debug**, build the projet inside a `build_debug` folder.
 
-You can specify the "--no-check" option when running the bench binary to disable result checking :
+* You can specify the "--no-check" option when running the bench binary to disable result checking :
 ```bash
 ./bin/Bench --no-check
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ conan install .. --build missing
 
 ## To bench your own code
 
-### Create a new cmake target
+### Compile your code
+There are two ways to get your code compiled:
+* Directly copy the function in the file `src/to_bench.cu`
+* Create a new cmake target
+
+
+#### Create a new cmake target
 
 In `CMakeLists.txt`:
 * Create a new library as follows:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,43 @@ You can specify the "--no-check" option when running the bench binary to disable
 
 ## To bench your own code
 
-- Place the functions you need to bench inside "src/to_bench.cu"
-- Add them in "bench/main.cc" to enable benching
+### Create a new cmake target
+
+In `CMakeLists.txt`:
+* Create a new library as follows:
+```cmake
+add_library(LIB_NAME
+	SOURCE_FILE1
+	SOURCE_FILE2
+	...
+)
+```
+* Link this library to the `Bench` target (add this library among the others) as follows:
+```cmake
+target_link_libraries(Bench LIB_NAME async_memcpy GTest::GTest benchmark::benchmark TestHelpers)
+```
+* Note: be careful not to have the same functions name for exported functions between libraries (avoid multiple definition compilation error)
+
+### Create new benches
+
+In `bench/main.cc`:
+* Include the header file containing the function(s) to bench `#include header_file.cuh` if not already in the included files
+* Define a new bench as follows
+```c++
+BENCHMARK_DEFINE_F(Fixture, BENCH_NAME)
+(benchmark::State &st)
+{
+    this->bench(st, NAME_OF_THE_FUNCTION_TO_BENCH, BUFFER_SIZE);
+}
+```
+* Register the new bench as follows
+```c++
+BENCHMARK_REGISTER_F(Fixture, BENCH_NAME)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+```
+* Note: a template of this steps can directly be found in `src/main.cc`
+
+### Extra ressources
 - You can use premade host_shared_ptr to allocate data
 - You can use premade test_helper to test your result

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In `bench/main.cc`:
 BENCHMARK_DEFINE_F(Fixture, BENCH_NAME)
 (benchmark::State &st)
 {
-    this->bench(st, NAME_OF_THE_FUNCTION_TO_BENCH, BUFFER_SIZE);
+    this->bench(st, NAME_OF_THE_FUNCTION_TO_BENCH, BUFFER_SIZE, FUNCTION_ARGS...);
 }
 ```
 * Register the new bench as follows
@@ -96,6 +96,7 @@ BENCHMARK_REGISTER_F(Fixture, BENCH_NAME)
     ->Unit(benchmark::kMillisecond);
 ```
 * Note: a template of this steps can directly be found in `src/main.cc`
+* Note: the first function argument must be a `cuda_tools::host_shared_ptr<int>`
 
 ### Extra ressources
 - You can use premade host_shared_ptr to allocate data

--- a/bench/main.cc
+++ b/bench/main.cc
@@ -1,22 +1,27 @@
-#include "test_helpers.hh"
 #include "cuda_tools/host_shared_ptr.cuh"
+#include "test_helpers.hh"
 #include "to_bench.cuh"
 
 #include <benchmark/benchmark.h>
 
 class Fixture : public benchmark::Fixture
 {
-public:
+  public:
     static bool no_check;
 
-    void bench(benchmark::State &st, std::function<void(cuda_tools::host_shared_ptr<int>)> callback, std::size_t size)
+    template <typename... Args>
+    void bench(benchmark::State& st,
+               void (*callback)(cuda_tools::host_shared_ptr<int>, Args...),
+               std::size_t size,
+               Args... args)
     {
         cuda_tools::host_shared_ptr<int> buffer(size);
 
         for (auto _ : st)
-            callback(buffer);
+            callback(buffer, args...);
 
-        st.SetBytesProcessed(int64_t(st.iterations()) * int64_t(size * sizeof(int)));
+        st.SetBytesProcessed(int64_t(st.iterations()) *
+                             int64_t(size * sizeof(int)));
 
         if (!no_check)
             check_buffer(buffer);
@@ -26,14 +31,13 @@ public:
 bool Fixture::no_check = false;
 
 BENCHMARK_DEFINE_F(Fixture, First_Bench)
-(benchmark::State &st)
-{
-    this->bench(st, to_bench, 1 << 9);
-}
+(benchmark::State& st) { this->bench(st, to_bench, 1 << 9); }
 
-BENCHMARK_REGISTER_F(Fixture, First_Bench)->UseRealTime()->Unit(benchmark::kMillisecond);
+BENCHMARK_REGISTER_F(Fixture, First_Bench)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     ::benchmark::Initialize(&argc, argv);
 

--- a/bench/main.cc
+++ b/bench/main.cc
@@ -30,10 +30,21 @@ class Fixture : public benchmark::Fixture
 
 bool Fixture::no_check = false;
 
+// Basic bench
+// Remove me (it is simply a sample)
 BENCHMARK_DEFINE_F(Fixture, First_Bench)
 (benchmark::State& st) { this->bench(st, to_bench, 1 << 9); }
 
 BENCHMARK_REGISTER_F(Fixture, First_Bench)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+
+// Bench a function with multiple arguments
+// Remove me (it is simply a sample)
+BENCHMARK_DEFINE_F(Fixture, Bench_Multiple_Args)
+(benchmark::State& st) { this->bench(st, to_bench, 1 << 9, 64, 1); }
+
+BENCHMARK_REGISTER_F(Fixture, Bench_Multiple_Args)
     ->UseRealTime()
     ->Unit(benchmark::kMillisecond);
 

--- a/bench/main.cc
+++ b/bench/main.cc
@@ -9,16 +9,14 @@ class Fixture : public benchmark::Fixture
   public:
     static bool no_check;
 
-    template <typename... Args>
-    void bench(benchmark::State& st,
-               void (*callback)(cuda_tools::host_shared_ptr<int>, Args...),
-               std::size_t size,
-               Args... args)
+    template <typename FUNC, typename... Args>
+    void
+    bench(benchmark::State& st, FUNC callback, std::size_t size, Args&&... args)
     {
         cuda_tools::host_shared_ptr<int> buffer(size);
 
         for (auto _ : st)
-            callback(buffer, args...);
+            callback(buffer, std::forward<Args>(args)...);
 
         st.SetBytesProcessed(int64_t(st.iterations()) *
                              int64_t(size * sizeof(int)));
@@ -33,7 +31,7 @@ bool Fixture::no_check = false;
 // Basic bench
 // Remove me (it is simply a sample)
 BENCHMARK_DEFINE_F(Fixture, First_Bench)
-(benchmark::State& st) { this->bench(st, to_bench, 1 << 9); }
+(benchmark::State& st) { this->bench(st, to_bench_single, 1 << 9); }
 
 BENCHMARK_REGISTER_F(Fixture, First_Bench)
     ->UseRealTime()
@@ -42,7 +40,7 @@ BENCHMARK_REGISTER_F(Fixture, First_Bench)
 // Bench a function with multiple arguments
 // Remove me (it is simply a sample)
 BENCHMARK_DEFINE_F(Fixture, Bench_Multiple_Args)
-(benchmark::State& st) { this->bench(st, to_bench, 1 << 9, 64, 1); }
+(benchmark::State& st) { this->bench(st, to_bench_multiple, 1 << 9, 64, 1); }
 
 BENCHMARK_REGISTER_F(Fixture, Bench_Multiple_Args)
     ->UseRealTime()

--- a/src/to_bench.cu
+++ b/src/to_bench.cu
@@ -11,7 +11,7 @@ __global__ void kernel(cuda_tools::device_buffer<int> buffer)
         buffer[index] = 0;
 }
 
-void to_bench(cuda_tools::host_shared_ptr<int> buffer)
+void to_bench_single(cuda_tools::host_shared_ptr<int> buffer)
 {
     cuda_tools::device_buffer<int> device_buffer(buffer);
 
@@ -30,7 +30,7 @@ void to_bench(cuda_tools::host_shared_ptr<int> buffer)
     cudaDeviceSynchronize();
 }
 
-void to_bench(cuda_tools::host_shared_ptr<int> buffer,
+void to_bench_multiple(cuda_tools::host_shared_ptr<int> buffer,
               int tile_width,
               int tile_height)
 {

--- a/src/to_bench.cu
+++ b/src/to_bench.cu
@@ -1,29 +1,45 @@
 #include "to_bench.cuh"
 
-#include "cuda_tools/host_shared_ptr.cuh"
-#include "cuda_tools/device_buffer.cuh"
 #include "cuda_tools/cuda_error_checking.cuh"
+#include "cuda_tools/device_buffer.cuh"
+#include "cuda_tools/host_shared_ptr.cuh"
 
-__global__
-void kernel(cuda_tools::device_buffer<int> buffer)
+__global__ void kernel(cuda_tools::device_buffer<int> buffer)
 {
     int index = threadIdx.x + blockIdx.x * blockDim.x;
     if (index < buffer.size_)
         buffer[index] = 0;
 }
 
-
 void to_bench(cuda_tools::host_shared_ptr<int> buffer)
 {
     cuda_tools::device_buffer<int> device_buffer(buffer);
 
-    constexpr int TILE_WIDTH  = 64;
+    constexpr int TILE_WIDTH = 64;
     constexpr int TILE_HEIGHT = 1;
 
-    const int gx             = (buffer.size_ + TILE_WIDTH - 1) / TILE_WIDTH;
-    const int gy             = 1;
-    
+    const int gx = (buffer.size_ + TILE_WIDTH - 1) / TILE_WIDTH;
+    const int gy = 1;
+
     const dim3 block(TILE_WIDTH, TILE_HEIGHT);
+    const dim3 grid(gx, gy);
+
+    kernel<<<grid, block>>>(device_buffer);
+    kernel_check_error();
+
+    cudaDeviceSynchronize();
+}
+
+void to_bench(cuda_tools::host_shared_ptr<int> buffer,
+              int tile_width,
+              int tile_height)
+{
+    cuda_tools::device_buffer<int> device_buffer(buffer);
+
+    const int gx = (buffer.size_ + tile_width - 1) / tile_width;
+    const int gy = 1;
+
+    const dim3 block(tile_width, tile_height);
     const dim3 grid(gx, gy);
 
     kernel<<<grid, block>>>(device_buffer);

--- a/src/to_bench.cuh
+++ b/src/to_bench.cuh
@@ -3,3 +3,6 @@
 #include "cuda_tools/host_shared_ptr.cuh"
 
 void to_bench(cuda_tools::host_shared_ptr<int> buffer);
+void to_bench(cuda_tools::host_shared_ptr<int> buffer,
+              int tile_width,
+              int tile_height);

--- a/src/to_bench.cuh
+++ b/src/to_bench.cuh
@@ -2,7 +2,7 @@
 
 #include "cuda_tools/host_shared_ptr.cuh"
 
-void to_bench(cuda_tools::host_shared_ptr<int> buffer);
-void to_bench(cuda_tools::host_shared_ptr<int> buffer,
+void to_bench_single(cuda_tools::host_shared_ptr<int> buffer);
+void to_bench_multiple(cuda_tools::host_shared_ptr<int> buffer,
               int tile_width,
               int tile_height);


### PR DESCRIPTION
Pour éviter les cas où les fonctions ont plusieurs arguments, il suffit de créer un bench pour chaque combinaisons de paramètres et plus besoin d'écrire plusieurs fonctions.

Ca gère aussi l'overloading des functions.

Je suis passé par des templates et pointeur sur fonction.
Je me suis inspiré de ce [post stackoverflow](https://stackoverflow.com/questions/9242234/c11-variadic-stdfunction-parameter)
```c++
template <typename... Args>
void bench(benchmark::State& st,
           void (*callback)(cuda_tools::host_shared_ptr<int>, 
           std::size_t,
           Args... args)
```

La fonction renvoit void, prend un host_shared_ptr comme premier argument et ensuite tous les autres arguments (potentiellement aucun). De plus, il suffit de donner ces arguments directement à la fin des arguments de bench

Par contre, est ce que tu veux qu'on template le type de retour ? J'ai testé et ça fonctionnerai mais quand on appelle la fonction bench on est obligé de  préciser le template parce qu'il n'arrive pas à le déduire. Ca donnerait
```c++
BENCHMARK_DEFINE_F(Fixture, Bench_Multiple_Args)
(benchmark::State& st) { this->bench<void>(st, to_bench, 1 << 9, 64, 1); }
```
Dit moi ce que tu en penses ^^